### PR TITLE
refactor: :recycle: The iceServer object is added to the createWebRtcTransport response

### DIFF
--- a/config.js
+++ b/config.js
@@ -23,7 +23,7 @@ module.exports = {
     },
     ingressHost: process.env.MEDIASOUP_INGRESS_HOST,
   },
-  //IceServer config
+  //IceServer config deprecated
   iceserver: {
     enableIceServer: process.env.MEDIASOUP_CLIENT_ENABLE_ICESERVER || 'true',
     iceServerHost: process.env.MEDIASOUP_CLIENT_ICESERVER_HOST || 'localhost',
@@ -32,6 +32,13 @@ module.exports = {
     iceServerUser: process.env.MEDIASOUP_CLIENT_ICESERVER_USER || '',
     iceServerPass: process.env.MEDIASOUP_CLIENT_ICESERVER_PASS || '',
   },
+  iceServers: [
+    {
+      urls: `turn:${process.env.MEDIASOUP_CLIENT_ICESERVER_HOST}:${process.env.MEDIASOUP_CLIENT_ICESERVER_PORT}?transport=${process.env.MEDIASOUP_CLIENT_ICESERVER_PROTO}`,
+      username: process.env.MEDIASOUP_CLIENT_ICESERVER_USER,
+      credential: process.env.MEDIASOUP_CLIENT_ICESERVER_PASS
+    }
+  ],
   // mediasoup settings.
   mediasoup: {
     // Number of mediasoup workers to launch.

--- a/lib/Room.js
+++ b/lib/Room.js
@@ -868,7 +868,8 @@ class Room extends EventEmitter {
           iceCandidates: transport.iceCandidates,
           dtlsParameters: transport.dtlsParameters,
           sctpParameters: transport.sctpParameters,
-          iceServer: config.iceserver,
+          iceserver: config.iceserver, // Deprecated
+          iceServers: config.iceServers,
         })
 
         const { maxIncomingBitrate } = config.mediasoup.webRtcTransportOptions


### PR DESCRIPTION
Resolved Issue #10 ICE Servers on createWebRtcTransport response

Adding to the server configuration an array of iceServer objects, which will be constructed using the configured environment variables. This object is added to the server's response when there is a request to create a transport.

