### PR TITLE
feat: enable case-sensitive routing in Express app

### DIFF
--- a/server.js
+++ b/server.js
@@ -153,6 +153,8 @@ async function createExpressApp() {
 
   expressApp = express()
 
+  expressApp.set('case sensitive routing', true);
+
   expressApp.use(express.static('public'))
 
   expressApp.use(bodyParser.json())


### PR DESCRIPTION
This PR introduces a configuration change to enable case-sensitive routing in the Express application by setting app.set('case sensitive routing', true). This ensures that routes distinguish between uppercase and lowercase letters, improving route handling consistency and preventing potential misrouting due to case differences.