### PR TITLE
fix: filename imports into index.html with new name demo 

### DIFF
--- a/demo/webclient/index.html
+++ b/demo/webclient/index.html
@@ -2,12 +2,12 @@
 
 <html>
 	<head>
-		<title>2060 WebRTC Mobiera</title>
+		<title>2060 webrtc-webclient</title>
 		<meta charset='UTF-8'>
 		<meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no'>
-		<meta name='description' content='mediasoup demo - Cutting Edge WebRTC Video Conferencing'>
+		<meta name='description' content='WebRTC web client based on mediasoup demo app v3'>
 
-		<link rel='stylesheet' href='/mediasoup-demo-app.css?v=foo2'>
+		<link rel='stylesheet' href='/webrtc-webclient.css?v=foo2'>
 
 		<script src='/resources/js/antiglobal.js'></script>
 		<script>
@@ -19,7 +19,7 @@
 				setInterval(window.antiglobal, 180000);
 			}
 		</script>
-		<script async src='/mediasoup-demo-app.js?v=foo2'></script>
+		<script async src='/webrtc-webclient.js?v=foo2'></script>
 	</head>
 
 	<body>


### PR DESCRIPTION
Update index.html imports files because when the project changed name gulp file compile with this new name but index.html template was not updated.

This caused the client to not find the corresponding files and not display any information.