### PR TITLE
fix: copy pnpm-lock.yaml during Docker build for monorepo apps

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -78,6 +78,7 @@ jobs:
             if [ "$APP" == "loadbalancer" ]; then
               IMAGE_NAME="webrtc-loadbalancer"
             fi
+            cp pnpm-lock.yaml apps/$APP/
             docker build -f apps/$APP/Dockerfile -t $DH_USERNAME/$IMAGE_NAME:$IMAGE_TAG apps/$APP/
           done
 


### PR DESCRIPTION
This change ensures Docker builds succeed by making the monorepo root pnpm-lock.yaml available inside each app. 