### PR TITLE
refactor: Resolve TS18046 Error types webrtc-server

### DIFF
--- a/apps/webrtc-server/src/lib/Room.ts
+++ b/apps/webrtc-server/src/lib/Room.ts
@@ -8,6 +8,7 @@ import { config } from '../config/config.server'
 import { Device } from './room.interfaces'
 import * as throttle from '@sitespeed.io/throttle'
 import { Producer } from 'mediasoup/node/lib/types'
+import { getErrorMessage } from '../utils/error-utils'
 
 @Injectable()
 export class Room extends EventEmitter {
@@ -176,8 +177,10 @@ export class Room extends EventEmitter {
       try {
         await this.handlePeerRequest(peer, request, accept, reject)
       } catch (error) {
-        this.logger.error(`Failed to handle request [peerId:${peerId}, method:${request.method}]: ${error.message}`)
-        reject(error)
+        this.logger.error(
+          `Failed to handle request [peerId:${peerId}, method:${request.method}]: ${getErrorMessage(error)}`,
+        )
+        reject(error instanceof Error ? error : new Error(getErrorMessage(error)))
       }
     })
 
@@ -1128,7 +1131,7 @@ export class Room extends EventEmitter {
         } catch (error) {
           this.logger.error('Failed to stop network throttle: %o', error)
 
-          reject({ status: 500, error: `Failed to stop network throttle: ${error.message}` })
+          reject({ status: 500, error: `Failed to stop network throttle: ${getErrorMessage(error)}` })
         }
 
         break
@@ -1785,8 +1788,8 @@ export class Room extends EventEmitter {
         streamId: dataConsumer.sctpStreamParameters.streamId,
       }
     } catch (error) {
-      this.logger.error(`Failed to create DataConsumer: ${error.message}`)
-      throw new Error(`Failed to create DataConsumer: ${error.message}`)
+      this.logger.error(`Failed to create DataConsumer: ${getErrorMessage(error)}`)
+      throw new Error(`Failed to create DataConsumer: ${getErrorMessage(error)}`)
     }
   }
 
@@ -1852,8 +1855,8 @@ export class Room extends EventEmitter {
         id: dataProducer.id,
       }
     } catch (error) {
-      this.logger.error(`Failed to create DataProducer: ${error.message}`)
-      throw new Error(`Failed to create DataProducer: ${error.message}`)
+      this.logger.error(`Failed to create DataProducer: ${getErrorMessage(error)}`)
+      throw new Error(`Failed to create DataProducer: ${getErrorMessage(error)}`)
     }
   }
 
@@ -1945,7 +1948,7 @@ export class Room extends EventEmitter {
             volume: volume,
           })
           .catch((error: Error) => {
-            this.logger.error('Failed to notify active speaker:', error.message)
+            this.logger.error('Failed to notify active speaker:', getErrorMessage(error))
           })
       }
     })
@@ -1957,7 +1960,7 @@ export class Room extends EventEmitter {
       // Notify all connected peers about no active speaker.
       for (const peer of this.getJoinedPeers()) {
         peer.notify('activeSpeaker', { peerId: null }).catch((error: Error) => {
-          this.logger.error('Failed to notify silence event:', error.message)
+          this.logger.error('Failed to notify silence event:', getErrorMessage(error))
         })
       }
     })
@@ -1975,7 +1978,7 @@ export class Room extends EventEmitter {
         // Additional logic can be added here to notify peers or perform actions
         // based on the dominant speaker event.
       } catch (error) {
-        this.logger.error('Error handling "dominantspeaker" event:', error.message)
+        this.logger.error('Error handling "dominantspeaker" event:', getErrorMessage(error))
       }
     })
   }

--- a/apps/webrtc-server/src/lib/notification.service.ts
+++ b/apps/webrtc-server/src/lib/notification.service.ts
@@ -3,6 +3,7 @@ import { HttpService } from '@nestjs/axios'
 import { firstValueFrom } from 'rxjs'
 import { AxiosInstance } from 'axios'
 import axios from 'axios'
+import { getErrorMessage } from '../utils/error-utils'
 
 @Injectable()
 export class NotificationService {
@@ -31,7 +32,9 @@ export class NotificationService {
         const response = await firstValueFrom(this.httpService.post(eventNotificationUri, notificationData))
         this.logger.log(`[sendNotification] Notification sent to ${eventNotificationUri}: ${response.status}`)
       } catch (error) {
-        this.logger.error(`[sendNotification] Failed to send notification to ${eventNotificationUri}: ${error.message}`)
+        this.logger.error(
+          `[sendNotification] Failed to send notification to ${eventNotificationUri}: ${getErrorMessage(error)}`,
+        )
       }
     } else {
       this.logger.warn(
@@ -53,7 +56,7 @@ export class NotificationService {
         this.logger.log(`[post] Request sent to ${uri}: ${response.status}`)
         return response
       } catch (error) {
-        this.logger.error(`[post] Failed to send POST request to ${uri}: ${error.message}`)
+        this.logger.error(`[post] Failed to send POST request to ${uri}: ${getErrorMessage(error)}`)
         return error
       }
     } else {

--- a/apps/webrtc-server/src/rooms/rooms.controller.spec.ts
+++ b/apps/webrtc-server/src/rooms/rooms.controller.spec.ts
@@ -3,6 +3,7 @@ import { RoomsController } from './rooms.controller'
 import { RoomsService } from './rooms.service'
 import { HttpException, HttpStatus } from '@nestjs/common'
 import { CreateBroadcasterDto, CreateRoomDto } from 'src/rooms/dto/rooms.dto'
+import { getErrorMessage } from '../utils/error-utils'
 
 describe('RoomsController', () => {
   let controller: RoomsController
@@ -77,8 +78,10 @@ describe('RoomsController', () => {
         await controller.createRoom(roomId, createRoomDto)
       } catch (error) {
         expect(error).toBeInstanceOf(HttpException)
-        expect(error.message).toBe('Failed to create room: Test Error')
-        expect(error.getStatus()).toBe(HttpStatus.INTERNAL_SERVER_ERROR)
+        expect(getErrorMessage(error)).toBe('Failed to create room: Test Error')
+        if (error instanceof HttpException) {
+          expect(error.getStatus()).toBe(HttpStatus.INTERNAL_SERVER_ERROR)
+        }
       }
     })
   })

--- a/apps/webrtc-server/src/rooms/rooms.controller.ts
+++ b/apps/webrtc-server/src/rooms/rooms.controller.ts
@@ -12,6 +12,7 @@ import {
   DeleteBroadcasterDto,
 } from './dto/rooms.dto'
 import { ApiBody, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger'
+import { getErrorMessage } from '../utils/error-utils'
 
 @ApiTags('rooms')
 @Controller('rooms')
@@ -96,8 +97,8 @@ export class RoomsController {
     try {
       return await this.roomsService.createRoom(roomId, eventNotificationUri, maxPeerCount)
     } catch (error) {
-      this.logger.error(`${error.message}`)
-      throw new HttpException(`${error.message}`, HttpStatus.INTERNAL_SERVER_ERROR)
+      this.logger.error(`${getErrorMessage(error)}`)
+      throw new HttpException(`${getErrorMessage(error)}`, HttpStatus.INTERNAL_SERVER_ERROR)
     }
   }
 
@@ -143,7 +144,7 @@ export class RoomsController {
       const room = await this.roomsService.getOrCreateRoom({ roomId })
       return room.getRouterRtpCapabilities()
     } catch (error) {
-      throw new HttpException(`Failed to get room information: ${error.message}`, HttpStatus.NOT_FOUND)
+      throw new HttpException(`Failed to get room information: ${getErrorMessage(error)}`, HttpStatus.NOT_FOUND)
     }
   }
 
@@ -229,7 +230,10 @@ export class RoomsController {
     try {
       return await this.roomsService.createBroadcaster(roomId, createBroadcasterDto)
     } catch (error) {
-      throw new HttpException(`Failed to create broadcaster: ${error.message}`, HttpStatus.INTERNAL_SERVER_ERROR)
+      throw new HttpException(
+        `Failed to create broadcaster: ${getErrorMessage(error)}`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      )
     }
   }
 
@@ -270,7 +274,10 @@ export class RoomsController {
       await this.roomsService.deleteBroadcaster(roomId, broadcasterId)
       return { message: 'Broadcaster deleted successfully' }
     } catch (error) {
-      throw new HttpException(`Failed to delete broadcaster: ${error.message}`, HttpStatus.INTERNAL_SERVER_ERROR)
+      throw new HttpException(
+        `Failed to delete broadcaster: ${getErrorMessage(error)}`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      )
     }
   }
 
@@ -352,7 +359,7 @@ export class RoomsController {
       return await this.roomsService.createBroadcasterTransport(roomId, broadcasterId, createBroadcasterTransportDto)
     } catch (error) {
       throw new HttpException(
-        `Failed to create broadcaster transport: ${error.message}`,
+        `Failed to create broadcaster transport: ${getErrorMessage(error)}`,
         HttpStatus.INTERNAL_SERVER_ERROR,
       )
     }
@@ -414,7 +421,7 @@ export class RoomsController {
       return { message: 'Broadcaster transport connected successfully' }
     } catch (error) {
       throw new HttpException(
-        `Failed to connect broadcaster transport: ${error.message}`,
+        `Failed to connect broadcaster transport: ${getErrorMessage(error)}`,
         HttpStatus.INTERNAL_SERVER_ERROR,
       )
     }
@@ -496,7 +503,7 @@ export class RoomsController {
       return producerData
     } catch (error) {
       throw new HttpException(
-        `Failed to create broadcaster produces transport: ${error.message}`,
+        `Failed to create broadcaster produces transport: ${getErrorMessage(error)}`,
         HttpStatus.INTERNAL_SERVER_ERROR,
       )
     }
@@ -577,7 +584,7 @@ export class RoomsController {
       return { data }
     } catch (error) {
       throw new HttpException(
-        `Failed to create broadcaster consumer transport: ${error.message}`,
+        `Failed to create broadcaster consumer transport: ${getErrorMessage(error)}`,
         HttpStatus.INTERNAL_SERVER_ERROR,
       )
     }
@@ -651,8 +658,11 @@ export class RoomsController {
       )
       return data
     } catch (error) {
-      this.logger.error(`Failed to create DataConsumer: ${error.message}`)
-      throw new HttpException(`Failed to create DataConsumer: ${error.message}`, HttpStatus.INTERNAL_SERVER_ERROR)
+      this.logger.error(`Failed to create DataConsumer: ${getErrorMessage(error)}`)
+      throw new HttpException(
+        `Failed to create DataConsumer: ${getErrorMessage(error)}`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      )
     }
   }
 
@@ -727,7 +737,10 @@ export class RoomsController {
       const data = await this.roomsService.createBroadcasterDataProducer(roomId, broadcasterId, transportId, dto)
       return { status: 200, data }
     } catch (error) {
-      throw new HttpException(`Failed to create DataProducer: ${error.message}`, HttpStatus.INTERNAL_SERVER_ERROR)
+      throw new HttpException(
+        `Failed to create DataProducer: ${getErrorMessage(error)}`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      )
     }
   }
 }

--- a/apps/webrtc-server/src/rooms/rooms.service.ts
+++ b/apps/webrtc-server/src/rooms/rooms.service.ts
@@ -26,6 +26,8 @@ import { Server } from 'https'
 import { NotificationService } from '../lib/notification.service'
 import { ConfigService } from '@nestjs/config'
 
+import { getErrorDetails, getErrorMessage } from '../utils/error-utils'
+
 @Injectable()
 export class RoomsService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(RoomsService.name)
@@ -75,8 +77,10 @@ export class RoomsService implements OnModuleInit, OnModuleDestroy {
           this.logger.log(`Peer joined [roomId:${roomId}, peerId:${peerId}]`)
         })
         .catch((error) => {
-          this.logger.error(`Failed to handle connection [roomId:${roomId}, peerId:${peerId}]: ${error.message}`)
-          reject(500, error.message)
+          this.logger.error(
+            `Failed to handle connection [roomId:${roomId}, peerId:${peerId}]: ${getErrorMessage(error)}`,
+          )
+          reject(500, getErrorMessage(error))
         })
     })
   }
@@ -122,7 +126,7 @@ export class RoomsService implements OnModuleInit, OnModuleDestroy {
       })
       this.logger.log('[Protoo-server] WebSocket initialized.')
     } catch (error) {
-      this.logger.error('Error during Protoo server initialization', error.stack)
+      this.logger.error('Error during Protoo server initialization', getErrorDetails(error))
       throw error
     }
   }
@@ -144,7 +148,7 @@ export class RoomsService implements OnModuleInit, OnModuleDestroy {
         this.logger.log(`[registerLoadbalancer] Successfully registered WebRTC server with Load Balancer.`)
       } catch (error) {
         this.logger.error(
-          `[registerLoadbalancer] Failed to register with WebRTC Load Balancer at ${loadbalancerUrl}: ${error.message}`,
+          `[registerLoadbalancer] Failed to register with WebRTC Load Balancer at ${loadbalancerUrl}: ${getErrorMessage(error)}`,
         )
       }
     } else {
@@ -209,7 +213,7 @@ export class RoomsService implements OnModuleInit, OnModuleDestroy {
 
         this.mediasoupWorkers.push(worker)
       } catch (error) {
-        this.logger.error(`Failed to initialize Mediasoup Worker: ${error.message}`)
+        this.logger.error(`Failed to initialize Mediasoup Worker: ${getErrorMessage(error)}`)
         throw new InternalServerErrorException('Failed to initialize Mediasoup workers')
       }
     }
@@ -325,8 +329,11 @@ export class RoomsService implements OnModuleInit, OnModuleDestroy {
 
       return room
     } catch (error) {
-      this.logger.error(`Failed to create or retrieve room [roomId:${roomId}]: ${error.message}`)
-      throw new HttpException(`Failed to create or retrieve room: ${error.message}`, HttpStatus.INTERNAL_SERVER_ERROR)
+      this.logger.error(`Failed to create or retrieve room [roomId:${roomId}]: ${getErrorMessage(error)}`)
+      throw new HttpException(
+        `Failed to create or retrieve room: ${getErrorMessage(error)}`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      )
     }
   }
 
@@ -397,8 +404,8 @@ export class RoomsService implements OnModuleInit, OnModuleDestroy {
         roomId: roomIdToUse,
       }
     } catch (error) {
-      this.logger.error(`[createRoom] Error creating or retrieving room: ${error.message}`)
-      throw new HttpException({ error: error.message }, HttpStatus.INTERNAL_SERVER_ERROR)
+      this.logger.error(`[createRoom] Error creating or retrieving room: ${getErrorMessage(error)}`)
+      throw new HttpException({ error: getErrorMessage(error) }, HttpStatus.INTERNAL_SERVER_ERROR)
     }
   }
 
@@ -423,7 +430,7 @@ export class RoomsService implements OnModuleInit, OnModuleDestroy {
       this.logger.log(`Broadcaster created in room "${roomId}"`)
       return broadcasterData
     } catch (error) {
-      this.logger.error(`Failed to create broadcaster in room "${roomId}": ${error.message}`)
+      this.logger.error(`Failed to create broadcaster in room "${roomId}": ${getErrorMessage(error)}`)
       throw error
     }
   }
@@ -447,7 +454,7 @@ export class RoomsService implements OnModuleInit, OnModuleDestroy {
       this.logger.log(`Broadcaster with id "${broadcasterId}" deleted from room "${roomId}"`)
     } catch (error) {
       this.logger.error(
-        `Failed to delete broadcaster with id "${broadcasterId}" from room "${roomId}": ${error.message}`,
+        `Failed to delete broadcaster with id "${broadcasterId}" from room "${roomId}": ${getErrorMessage(error)}`,
       )
       throw error
     }
@@ -490,7 +497,7 @@ export class RoomsService implements OnModuleInit, OnModuleDestroy {
       })
     } catch (error) {
       // Throw a generic error if the transport creation fails
-      throw new Error(`Failed to create broadcaster transport: ${error.message}`)
+      throw new Error(`Failed to create broadcaster transport: ${getErrorMessage(error)}`)
     }
   }
 
@@ -521,7 +528,7 @@ export class RoomsService implements OnModuleInit, OnModuleDestroy {
         dtlsParameters: dto.dtlsParameters,
       })
     } catch (error) {
-      throw new Error(`Failed to connect broadcaster transport: ${error.message}`)
+      throw new Error(`Failed to connect broadcaster transport: ${getErrorMessage(error)}`)
     }
   }
 
@@ -556,7 +563,7 @@ export class RoomsService implements OnModuleInit, OnModuleDestroy {
 
       return producerData
     } catch (error) {
-      throw new BadRequestException(`Failed to create broadcaster producer: ${error.message}`)
+      throw new BadRequestException(`Failed to create broadcaster producer: ${getErrorMessage(error)}`)
     }
   }
 

--- a/apps/webrtc-server/src/utils/error-utils.ts
+++ b/apps/webrtc-server/src/utils/error-utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Returns a safe string message from any thrown value.
+ */
+export function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * Returns both message and stack trace (if available) from any thrown value.
+ * Useful for logging errors in depth.
+ */
+export function getErrorDetails(error: unknown): { message: string; stack?: string } {
+  if (error instanceof Error) {
+    return { message: error.message, stack: error.stack }
+  }
+  return { message: String(error) }
+}

--- a/apps/webrtc-server/tsconfig.build.json
+++ b/apps/webrtc-server/tsconfig.build.json
@@ -9,7 +9,6 @@
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false,
-    "useUnknownInCatchVariables": false,
     "declaration": true,
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
This PR resolves TypeScript error TS18046 (error is of type 'unknown') by safely handling unknown errors using centralized utility functions. It replaces all unsafe uses of error.message and error.stack with proper guards via instanceof and helper functions.

- Fixes TS18046 in all try/catch blocks and others
- Introduced error-utils.ts with getErrorMessage, getErrorDetails
- Replaced unsafe error.message and error.stack usage with type-safe helpers