### PR TITLE
fix: fix image definition webrtc-load-balancer

### DIFF
--- a/charts/loadbalancer/templates/deployment.yaml
+++ b/charts/loadbalancer/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
     spec:
       containers:
         - name: {{ .Values.statefulset.containerName }}
-          image: io2060/webrtc-loadbalancer:{{ .Chart.Version }}
+          image: io2060/webrtc-load-balancer:{{ .Chart.Version }} 
           imagePullPolicy: {{ .Values.statefulset.pullPolicy }}
           resources:
             requests:


### PR DESCRIPTION
The chart template of loadbalancer set io2060/webrtc-loadbalancer image this cause error in deployment.